### PR TITLE
enable emoji replacement for :+1:, :smile_cat:, and so on

### DIFF
--- a/src/services/Esa/HtmlHandler.php
+++ b/src/services/Esa/HtmlHandler.php
@@ -207,7 +207,7 @@ class HtmlHandler
 
         $html = $this->crawler->html();
 
-        preg_match_all('/:(\w+):/', $html, $matches);
+        preg_match_all('/:([^\s:]+):/', $html, $matches);
 
         foreach (array_unique($matches[1]) as $name) {
             $code = sprintf(':%s:', $name);

--- a/tests/services/Esa/HtmlHandlerTest.php
+++ b/tests/services/Esa/HtmlHandlerTest.php
@@ -220,9 +220,11 @@ class HtmlHandlerTest extends TestCase
         $this->assertEquals(count(array_column($replacements, 'pattern')), count(array_column($replacements, 'replacement')));
     }
 
-    public function testReplaceEmojiCodes()
+    /**
+     * @dataProvider replaceEmojiCodesDataProvider
+     */
+    public function testReplaceEmojiCodes($code)
     {
-        $code = 'emoji';
         $imgTag = sprintf('<img src="%s" class="emoji" title=":%s:" alt=":%s:">', 'url', $code, $code);
 
         $this->crawler->html()->willReturn(sprintf('<p>:%s:</p>', $code));
@@ -234,9 +236,11 @@ class HtmlHandlerTest extends TestCase
         $this->SUT->replaceEmojiCodes();
     }
 
-    public function testReplaceEmojiCodesForDuplicatedEmojis()
+    /**
+     * @dataProvider replaceEmojiCodesDataProvider
+     */
+    public function testReplaceEmojiCodesForDuplicatedEmojis($code)
     {
-        $code = 'emoji';
         $imgTag = sprintf('<img src="%s" class="emoji" title=":%s:" alt=":%s:">', 'url', $code, $code);
 
         $this->crawler->html()->willReturn(sprintf('<p>:%s::%s:</p>', $code, $code));
@@ -246,6 +250,16 @@ class HtmlHandlerTest extends TestCase
         $this->emojiManager->getImageUrl($code)->willReturn('url');
 
         $this->SUT->replaceEmojiCodes();
+    }
+
+    public function replaceEmojiCodesDataProvider()
+    {
+        return [
+            ['emoji'],
+            ['+1'],
+            ['smile_cat'],
+            ['custom-emoji_code'],
+        ];
     }
 
     public function testReplaceHtml()


### PR DESCRIPTION
enable emojis which is out of `\w+` pattern (e.g. including `+`, `1`, `-`, `_`, and so on)