### PR TITLE
fix misidentification of emoji codes

### DIFF
--- a/src/services/Esa/HtmlHandler.php
+++ b/src/services/Esa/HtmlHandler.php
@@ -207,7 +207,7 @@ class HtmlHandler
 
         $html = $this->crawler->html();
 
-        preg_match_all('/:([^\s:]+):/', $html, $matches);
+        preg_match_all('/:([^\s:<>\'"]+):/', $html, $matches);
 
         foreach (array_unique($matches[1]) as $name) {
             $code = sprintf(':%s:', $name);

--- a/tests/services/Esa/HtmlHandlerTest.php
+++ b/tests/services/Esa/HtmlHandlerTest.php
@@ -262,6 +262,29 @@ class HtmlHandlerTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider replaceEmojiCodesForConfusablePatternDataProvider
+     */
+    public function testReplaceEmojiCodesForConfusablePattern($pattern)
+    {
+        $html = sprintf('<p>%s</p>', $pattern);
+
+        $this->crawler->html()->willReturn($html);
+        $this->crawler->clear()->shouldBeCalled();
+        $this->crawler->addHtmlContent($html)->shouldBeCalled();
+
+        $this->emojiManager->getImageUrl()->shouldNotBeCalled();
+
+        $this->SUT->replaceEmojiCodes();
+    }
+
+    public function replaceEmojiCodesForConfusablePatternDataProvider()
+    {
+        return [
+            ['<a href="https://foo/bar">https://foo/bar</a>'],  // ://foo/bar">https:
+        ];
+    }
+
     public function testReplaceHtml()
     {
         $this->crawler->html()->willReturn('html');


### PR DESCRIPTION
fix misidentification of emoji codes.
e.g. identification `://foo/bar">https:` as an emoji code from `<a href="https://foo/bar">https://foo/bar</a>`